### PR TITLE
feat: support for attaching custom payload for upload events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,97 @@
+### WebStorm+all ###
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/**/usage.statistics.xml
+.idea/**/dictionaries
+.idea/**/shelf
+
+# AWS User-specific
+.idea/**/aws.xml
+
+# Generated files
+.idea/**/contentModel.xml
+
+# Sensitive or high-churn files
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+.idea/**/dbnavigator.xml
+
+# Gradle
+.idea/**/gradle.xml
+.idea/**/libraries
+
+# Gradle and Maven with auto-import
+# When using Gradle or Maven with auto-import, you should exclude module files,
+# since they will be recreated, and may cause churn.  Uncomment if using
+# auto-import.
+# .idea/artifacts
+# .idea/compiler.xml
+# .idea/jarRepositories.xml
+# .idea/modules.xml
+# .idea/*.iml
+# .idea/modules
+# *.iml
+# *.ipr
+
+# CMake
+cmake-build-*/
+
+# Mongo Explorer plugin
+.idea/**/mongoSettings.xml
+
+# File-based project format
+*.iws
+
+# IntelliJ
+out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Cursive Clojure plugin
+.idea/replstate.xml
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+
+# Editor-based Rest Client
+.idea/httpRequests
+
+# Android studio 3.1+ serialized cache file
+.idea/caches/build_file_checksums.ser
+
+### WebStorm+all Patch ###
+# Ignores the whole .idea folder and all .iml files
+# See https://github.com/joeblau/gitignore.io/issues/186 and https://github.com/joeblau/gitignore.io/issues/360
+
+.idea/
+
+# Reason: https://github.com/joeblau/gitignore.io/issues/186#issuecomment-249601023
+
+*.iml
+modules.xml
+.idea/misc.xml
+*.ipr
+
+# Sonarlint plugin
+.idea/sonarlint
+
+# End of https://www.toptal.com/developers/gitignore/api/webstorm+all
+
 # Logs
 logs
 *.log

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kubric/asset-uploader",
-  "version": "0.0.20",
+  "version": "0.0.21",
   "description": "Upload assets to the kubric asset system",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",

--- a/src/packet.js
+++ b/src/packet.js
@@ -90,10 +90,10 @@ function readEntriesPromise(directoryReader) {
   }
 }
 
-export const getUploadPacket = (items, callback) =>
+export const getUploadPacket = (items, callback, payload) =>
   getAllFileEntries(items)
     .then(response => {
-      isFunction(callback) && callback(response);
+      isFunction(callback) && callback(response, payload);
       return response;
     });
   

--- a/src/util.js
+++ b/src/util.js
@@ -149,7 +149,7 @@ export function initiateChunkUpload(chunkTempIds, tempIds, name, id, chunkCount,
   return chunkTempIds;
 }
 
-export function getDataObject(isInternal, file, taskId, path) {
+export function getDataObject(isInternal, file, taskId, path, payload) {
   if (isInternal) {
     return {
       filename: file.name,
@@ -157,7 +157,8 @@ export function getDataObject(isInternal, file, taskId, path) {
       progress: 0,
       isComplete: false,
       isError: false,
-      taskId
+      taskId,
+      ...(payload && {payload}),
     }
   } else {
     return {
@@ -165,7 +166,8 @@ export function getDataObject(isInternal, file, taskId, path) {
       size: getHumanFileSize(file.size),
       path,
       taskId,
-      data: file._data
+      data: file._data,
+      ...(payload && {payload}),
     }
   }
 }


### PR DESCRIPTION
#### Summary

- Now an object with `{payload: "any_value"}` can be sent along with event data to `Uploader.upload()` method, which will be attached to all the event data that is being fired.
- Updated gitignore to ignore IDE files
- Bump version to `"0.0.21"`
