### PR TITLE
feat: send back size in bytes and last modified time of file in events

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kubric/asset-uploader",
-  "version": "0.0.21",
+  "version": "0.0.22",
   "description": "Upload assets to the kubric asset system",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",

--- a/src/util.js
+++ b/src/util.js
@@ -153,6 +153,8 @@ export function getDataObject(isInternal, file, taskId, path, payload) {
   if (isInternal) {
     return {
       filename: file.name,
+      sizeInBytes: file.size,
+      lastModified: file.lastModified,
       size: getHumanFileSize(file.size),
       progress: 0,
       isComplete: false,
@@ -163,6 +165,8 @@ export function getDataObject(isInternal, file, taskId, path, payload) {
   } else {
     return {
       filename: file.name,
+      sizeInBytes: file.size,
+      lastModified: file.lastModified,
       size: getHumanFileSize(file.size),
       path,
       taskId,


### PR DESCRIPTION
Signed-off-by: Abhijith Vijayan [KUBRIC] <78354201+abhijith-vijayan@users.noreply.github.com>

- now some events send back `sizeInBytes` and `lastModified` fields in response
- bump version to `v0.0.22`