### PR TITLE
refactor: send back file meta on all external upload events

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kubric/asset-uploader",
-  "version": "0.0.22",
+  "version": "0.0.23",
   "description": "Upload assets to the kubric asset system",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",

--- a/src/flowmanager.js
+++ b/src/flowmanager.js
@@ -5,7 +5,8 @@ import {
   EventEmitter,
   getChunkSizeArray,
   initiateChunkUpload,
-  getDataObject
+  getDataObject,
+  getFileMeta
 } from './util.js';
 import Axios from 'axios';
 import { messages, events, internalEvents } from './constants';
@@ -170,7 +171,7 @@ export default class FlowManager extends EventEmitter {
                 taskId: tempIds[0],
                 data: file._data,
                 ...uploadUrlData,
-                ...(payload && {payload})
+                ...getFileMeta(file, payload)
               });
               const extension = getExtension(file);
               if (url && isFileTypeSupported(extension)) {
@@ -196,7 +197,7 @@ export default class FlowManager extends EventEmitter {
                         taskId: tempIds[0],
                         data: fileData,
                         ...uploadUrlData,
-                        ...(payload && {payload})
+                        ...getFileMeta(file, payload)
                       });
                       this.emit(events.TOTAL_PROGRESS, {
                         progress: this.getQueuedTasksProgress(),
@@ -218,7 +219,7 @@ export default class FlowManager extends EventEmitter {
                       this.emit(events.FILE_UPLOAD_COMPLETED, {
                         data: fileData,
                         ...uploadUrlData,
-                        ...(payload && {payload})
+                        ...getFileMeta(file, payload)
                       });
                     }
                   })
@@ -233,7 +234,7 @@ export default class FlowManager extends EventEmitter {
                       taskId: tempIds[0],
                       data: fileData,
                       ...uploadUrlData,
-                      ...(payload && {payload})
+                      ...getFileMeta(file, payload)
                     });
                   });
               } else {
@@ -243,7 +244,7 @@ export default class FlowManager extends EventEmitter {
                 });
                 this.emit(events.GET_FILE_UPLOAD_URL_FAILED, {
                   taskId: tempIds[0],
-                  ...(payload && {payload})
+                  ...getFileMeta(file, payload)
                 });
               }
             });
@@ -262,7 +263,7 @@ export default class FlowManager extends EventEmitter {
                 progress: 1,
                 taskId: tempTaskId,
                 ...uploadUrlData,
-                ...(payload && {payload})
+                ...getFileMeta(file, payload)
               });
               const extension = getExtension(file);
               if (uploadUrlData && uploadUrlData.url && isFileTypeSupported(extension)) {
@@ -283,7 +284,7 @@ export default class FlowManager extends EventEmitter {
                         progress: percent,
                         taskId: tempTaskId,
                         ...uploadUrlData,
-                        ...(payload && {payload})
+                        ...getFileMeta(file, payload)
                       });
                       this.emit(events.TOTAL_PROGRESS, {
                         progress: this.getQueuedTasksProgress(),
@@ -300,7 +301,7 @@ export default class FlowManager extends EventEmitter {
                       data: fileData,
                       taskId: tempTaskId,
                       ...uploadUrlData,
-                      ...(payload && {payload})
+                      ...getFileMeta(file, payload)
                     });
                   })
                   .catch(error => {
@@ -313,7 +314,7 @@ export default class FlowManager extends EventEmitter {
                       error,
                       taskId: tempTaskId,
                       ...uploadUrlData,
-                      ...(payload && {payload})
+                      ...getFileMeta(file, payload)
                     });
                   });
               } else {
@@ -323,7 +324,7 @@ export default class FlowManager extends EventEmitter {
                 });
                 this.emit(events.GET_FILE_UPLOAD_URL_FAILED, {
                   taskId: tempTaskId,
-                  ...(payload && {payload})
+                  ...getFileMeta(file, payload)
                 });
               }
             });

--- a/src/util.js
+++ b/src/util.js
@@ -149,29 +149,32 @@ export function initiateChunkUpload(chunkTempIds, tempIds, name, id, chunkCount,
   return chunkTempIds;
 }
 
+export function getFileMeta(file, payload) {
+  return {
+    filename: file.name,
+    sizeInBytes: file.size,
+    lastModified: file.lastModified,
+    ...(payload && {payload}),
+  }
+}
+
 export function getDataObject(isInternal, file, taskId, path, payload) {
   if (isInternal) {
     return {
-      filename: file.name,
-      sizeInBytes: file.size,
-      lastModified: file.lastModified,
       size: getHumanFileSize(file.size),
       progress: 0,
       isComplete: false,
       isError: false,
       taskId,
-      ...(payload && {payload}),
+      ...getFileMeta(file, payload)
     }
   } else {
     return {
-      filename: file.name,
-      sizeInBytes: file.size,
-      lastModified: file.lastModified,
       size: getHumanFileSize(file.size),
       path,
       taskId,
       data: file._data,
-      ...(payload && {payload}),
+      ...getFileMeta(file, payload)
     }
   }
 }


### PR DESCRIPTION
Signed-off-by: Abhijith Vijayan [KUBRIC] <78354201+abhijith-vijayan@users.noreply.github.com>

- all external events now send back `filename`, `sizeInBytes`, `lastModified`
- bump version to `0.0.23`